### PR TITLE
Fix compilation of benchmarks

### DIFF
--- a/yi-rope.cabal
+++ b/yi-rope.cabal
@@ -61,6 +61,7 @@ benchmark bench
       base >=4.5 && <5
     , criterion
     , deepseq
+    , text
     , yi-rope
 
 source-repository head


### PR DESCRIPTION
Currently, the benchmarks fail to build when obtained from Hackage due to a missing `text` dependency.

See also https://github.com/fpco/stackage/issues/1372#issuecomment-213020065