### PR TITLE
Faster lines/lines'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,16 @@ before_install:
  - sudo add-apt-repository -y ppa:hvr/ghc
  - sudo apt-get update
  - sudo apt-get install cabal-install-$CABALVER ghc-$GHCVER libicu-dev
- - export PATH=/opt/ghc/$GHCVER/bin:$PATH
- - cabal-$CABALVER update
- - travis_retry cabal-$CABALVER install --only-dependencies --enable-tests --enable-benchmarks
+ - export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+ - cabal update
+ - travis_retry cabal install --only-dependencies --enable-tests --enable-benchmarks
 
 install:
- - cabal-$CABALVER install -j1 --enable-tests --enable-benchmarks
+ - cabal install -j1 --enable-tests --enable-benchmarks
 
 script:
- - cabal-$CABALVER test
- - cabal-$CABALVER bench
+ - cabal test
+ - cabal bench
 
 notifications:
   irc: "chat.freenode.net#yi"

--- a/bench/MainBenchmarkSuite.hs
+++ b/bench/MainBenchmarkSuite.hs
@@ -160,6 +160,7 @@ main = defaultMain $
   , onCharGroup "singleton" F.singleton
   , onTextGroup "countNewLines" F.countNewLines
   , onTextGroup "lines" F.lines
+  , onTextGroup "lines'" F.lines'
   , onSplitGroup "splitAt" F.splitAt
   , onSplitGroup "splitAtLine" F.splitAtLine
   , onTextGroup "toReverseString" F.toReverseString

--- a/src/Yi/Rope.hs
+++ b/src/Yi/Rope.hs
@@ -569,26 +569,11 @@ splitAtLine' p (YiString tr) = case viewl s of
 
 -- | This is like 'lines'' but it does *not* preserve newlines.
 --
--- Specifically, we just strip the newlines from the result of
--- 'lines''.
---
--- This behaves slightly differently than the old split: the number of
--- resulting strings here is equal to the number of newline characters
--- in the underlying string. This is much more consistent than the old
--- behaviour which blindly used @ByteString@s split and stitched the
--- result back together which was inconsistent with the rest of the
--- interface which worked with number of newlines.
+-- Implementation note: GHC does a pretty good job of optimizing
+-- this naive version. Hand coding a loop should be unnecessary
+-- here.
 lines :: YiString -> [YiString]
-lines = Prelude.map dropNl . lines'
-  where
-    dropNl (YiString t)  = case viewr t of
-      EmptyR -> Yi.Rope.empty
-      ts :> ch@(Chunk l tx) ->
-        YiString $ ts |- if TX.null tx
-                         then ch
-                         else case TX.last tx of
-                           '\n' -> Chunk (l - 1) (TX.init tx)
-                           _ -> ch
+lines = fmap fromText . TX.lines . toText
 
 -- | Splits the 'YiString' into a list of 'YiString' each containing a
 -- line.


### PR DESCRIPTION
The choice of chunk size of 1200 implies that we can create a fingertree of one line of text in constant time, so in general, it should be faster to split by lines with the whole text and then map it back into YiStrings.

cc @ethercrow 